### PR TITLE
add expanded class when collapsible is expanded

### DIFF
--- a/src/collapsible.js
+++ b/src/collapsible.js
@@ -14,6 +14,7 @@
 	var defaults = {
 		pluginClass: pluginName,
 		collapsedClass: pluginName + "-collapsed",
+		expandedClass: pluginName + "-expanded", // NOTE: don't use this class for showing/hiding collapsible-content. Instead, use it for expanded visual exceptions.
 		headerClass: pluginName + "-header",
 		contentClass: pluginName + "-content",
 		enhancedClass: pluginName + "-enhanced",
@@ -136,6 +137,7 @@
 		// used internally to expand without triggering events (for init)
 		_expand: function() {
 			this.element.removeClass( this.options.collapsedClass );
+			this.element.addClass( this.options.expandedClass );
 			this.collapsed = false;
 			this.header.attr( "aria-expanded", "true" );
 			this.content.attr( "aria-hidden", "false" );
@@ -150,6 +152,7 @@
 		// used internally to expand without triggering events (for init)
 		_collapse: function() {
 			this.element.addClass( this.options.collapsedClass );
+			this.element.removeClass( this.options.expandedClass );
 			this.collapsed = true;
 			this.header.attr( "aria-expanded", "false" );
 			this.content.attr( "aria-hidden", "true" );


### PR DESCRIPTION
NOTE: don't use this class for showing/hiding collapsible-content. Instead, use it for expanded visual exceptions.