### PR TITLE
This is a fix for #80. 

### DIFF
--- a/src/collapsible.tab.js
+++ b/src/collapsible.tab.js
@@ -69,10 +69,7 @@
 				e.stopPropagation();
 
 				if( !self.$tabHeader.is( '.' + activeTabClass ) ) {
-					var nonActives = $tabContainer.find( '.' + activeTabClass ).not( self.$tabHeader );
-					if( nonActives.length ){
-						deactivateTab( nonActives );
-					}
+					deactivateTab( $tabContainer.find( '.' + activeTabClass ) );
 					activateTab( self.$tabHeader );
 					self.expand();
 				}

--- a/src/collapsible.tab.js
+++ b/src/collapsible.tab.js
@@ -68,14 +68,14 @@
 				e.preventDefault();
 				e.stopPropagation();
 
-				if( self.$tabHeader.is( '.' + activeTabClass ) ) {
-					deactivateTab( self.$tabHeader );
-				} else {
-					deactivateTab( $tabContainer.find( '.' + activeTabClass ) );
+				if( !self.$tabHeader.is( '.' + activeTabClass ) ) {
+					var nonActives = $tabContainer.find( '.' + activeTabClass ).not( self.$tabHeader );
+					if( nonActives.length ){
+						deactivateTab( nonActives );
+					}
 					activateTab( self.$tabHeader );
+					self.expand();
 				}
-
-				self.toggle();
 			}).bind( "keydown", function( e ){
 				var $activeTab = $tabNav.find( "." + activeTabClass );
 				var direction;
@@ -100,7 +100,7 @@
 
 			if( !self.collapsed ) {
 				activateTab( self.$tabHeader );
-				self._expand();
+				self.expand();
 			}
 
 			$tabNav.append( self.$tabHeaderListItem.append( self.$tabHeader ) );


### PR DESCRIPTION
I have made the change in a way that it does not give a toggle-able option.

We should consider if that toggle behavior was in use anywhere but I think in the example that zach mentioned, where we have drop menus that toggle on hover, we use navbar, menu, and collapsible set, but not the tab plugin. So this should be okay...